### PR TITLE
[WIP] Changes needed to build non-static binary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include(MWLink)
 include(PrintInfo)
 include(CheckCFlag)
 include(MSVCFlags)
-include(PreferStatic)
+#include(PreferStatic)
 include(CMakeDependentOption)
 include(CheckFunctionExists)
 include(Profiling)
@@ -79,10 +79,6 @@ include(BOINCPaths)
 #These must be after CheckCFlags is included
 
 #TODO: Make sure to use Apple GCC for releases
-if(HAVE_FLAG_STATIC_LIBGCC AND NOT APPLE)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc")
-endif()
 
 if(HAVE_FLAG_PTHREAD)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
@@ -391,9 +387,6 @@ add_subdirectory(lua)
 add_subdirectory(dSFMT)
 add_definitions("${DSFMT_FLAGS}")
 
-if(SEPARATION_OPENCL)
-  add_subdirectory(libelf)
-endif()
 
 add_subdirectory(openpa)
 
@@ -444,7 +437,7 @@ if(BOINC_APPLICATION)
     add_subdirectory(boinc)
   else()
     message(STATUS "Trying to find BOINC")
-    find_package_static(BOINC REQUIRED)
+    find_package(BOINC REQUIRED)
   endif()
 
   include_directories(${BOINC_INCLUDE_DIR})

--- a/cmake_modules/CheckSSE2.cmake
+++ b/cmake_modules/CheckSSE2.cmake
@@ -209,15 +209,15 @@ mark_as_advanced(HAVE_AVX)
 
 
 set(CMAKE_REQUIRED_FLAGS "${SSE41_FLAGS}")
-check_include_files(smmintrin.h HAVE_SSE41 CACHE INTERNAL "Compiler has SSE4.1 headers")
+check_include_files(smmintrin.h HAVE_SSE41)
 mark_as_advanced(HAVE_SSE41)
 
 set(CMAKE_REQUIRED_FLAGS "${SSE3_FLAGS}")
-check_include_files(pmmintrin.h HAVE_SSE3 CACHE INTERNAL "Compiler has SSE3 headers")
+check_include_files(pmmintrin.h HAVE_SSE3)
 mark_as_advanced(HAVE_SSE3)
 
 set(CMAKE_REQUIRED_FLAGS "${SSE2_FLAGS}")
-check_include_files(emmintrin.h HAVE_SSE2 CACHE INTERNAL "Compiler has SSE2 headers")
+check_include_files(emmintrin.h HAVE_SSE2)
 mark_as_advanced(HAVE_SSE2)
 
 set(CMAKE_REQUIRED_FLAGS "")

--- a/cmake_modules/FindBOINC.cmake
+++ b/cmake_modules/FindBOINC.cmake
@@ -79,7 +79,7 @@ mark_as_advanced(BOINC_INCLUDE_DIR BOINC_LIBRARY )
 
 if(BOINC_FOUND)
    set(CMAKE_REQUIRED_INCLUDES ${BOINC_INCLUDE_DIR})
-   check_struct_has_member("BOINC_OPTIONS" "multi_thread" "boinc_api.h" HAVE_BOINC_OPTIONS_MULTI_THREAD)
+   check_struct_has_member("BOINC_OPTIONS" "multi_thread" "boinc/boinc_api.h" HAVE_BOINC_OPTIONS_MULTI_THREAD)
    if(NOT HAVE_BOINC_OPTIONS_MULTI_THREAD)
      message(FATAL_ERROR "Found BOINC libraries too old")
    endif()

--- a/cmake_modules/MWLink.cmake
+++ b/cmake_modules/MWLink.cmake
@@ -55,18 +55,6 @@ function(milkyway_link client_bin_name use_boinc use_static link_libs)
     set(link_flags "-static ${link_flags}")
   endif()
 
-  if(HAVE_FLAG_STATIC_LIBSTDCPP)
-    set(link_flags "${link_flags} -static-libstdc++ ")
-  else()
-    if(C_COMPILER_IS_PATHCC)
-      list(APPEND link_libs stl)
-    else()
-      if(NOT WIN32 AND 0)
-        # We should probably always statically link libstdc++
-        list(APPEND link_libs stdc++)
-      endif()
-    endif()
-  endif()
 
   set_target_properties(${client_bin_name}
                            PROPERTIES

--- a/milkyway/include/milkyway_sse2_intrin.h
+++ b/milkyway/include/milkyway_sse2_intrin.h
@@ -957,6 +957,7 @@ static __m128d _mm_pow_pd(__m128d base, __m128d power)
 	return gmx_mm_exp_pd(power * gmx_mm_log_pd(base));
 }
 
+ALWAYS_INLINE
 inline __m128d mw_abs_pd(__m128d x)
 {
     /*Homemade absolute value function.  Should work */


### PR DESCRIPTION
Changes to the build system to build non-static binary. Because static linking of system libraries only causes problems. This is work-in-progress, because this patch breaks static builds.